### PR TITLE
Fix onUserDestroy() being called within game loop

### DIFF
--- a/app/src/main/cpp/olcPixelGameEngine_Mobile.h
+++ b/app/src/main/cpp/olcPixelGameEngine_Mobile.h
@@ -7260,15 +7260,13 @@ namespace olc {
                 }
 
             }
+        }
 
-            // Allow the user to free resources if they have overrided the destroy function
-            if (!OnUserDestroy())
-            {
-                // User denied destroy for some reason, so continue running
-                bAtomActive = true;
-            }
-
-
+        // Allow the user to free resources if they have overrided the destroy function
+        if (!OnUserDestroy())
+        {
+            // User denied destroy for some reason, so continue running
+            bAtomActive = true;
         }
 
         platform->ThreadCleanUp();


### PR DESCRIPTION
Hello! 
First, thanks a lot for this really cool port to android/ios!
 
As i was trying it on my android device, I tried to log print each callback name to get a grips of when things are called as below:
```cpp
class PGE_Mobile : public olc::PixelGameEngine {
public:
    PGE_Mobile() {
      sAppName = "PGE Mobile Demo";
    }

public:
    bool OnUserCreate() override {
        LOGI("%s", __PRETTY_FUNCTION__);
        return true;
    }

    bool OnUserUpdate(float fElapsedTime) override {
       static float dt = 0.0f; 
       dt += fElapsedTime;
       if(dt >= 1.0f) {
          LOGI("%s", __PRETTY_FUNCTION__);
          dt = 0.0f;
        }
        return true;
    }


    bool OnUserDestroy() override {
        LOGI("%s", __PRETTY_FUNCTION__);
        return true;
    }

    void OnSaveStateRequested() override
    {
      LOGI("%s", __PRETTY_FUNCTION__);
    }

    void OnRestoreStateRequested() override
    {
      LOGI("%s", __PRETTY_FUNCTION__);
    }
};
```

and then the log cat shows calls to OnUserDestroy() every frame:
![image](https://github.com/Johnnyg63/OLCPGEMobile_AndroidStudio/assets/49657842/a493a06f-943a-4830-ab0a-9dd87f89474e)

At first I thought it was my phone, tried to restart it and the issue still persists, then had a look at the places OnUserDestroy() is called in [olcPixelGameEngine_Mobile.h](https://github.com/Johnnyg63/OLCPGEMobile_AndroidStudio/blob/master/app/src/main/cpp/olcPixelGameEngine_Mobile.h), then I noticed the [OnUserDestroy() was being called](https://github.com/Johnnyg63/OLCPGEMobile_AndroidStudio/blob/master/app/src/main/cpp/olcPixelGameEngine_Mobile.h#L7265) withing the [while(bAtomActive) {} game loop](https://github.com/Johnnyg63/OLCPGEMobile_AndroidStudio/blob/master/app/src/main/cpp/olcPixelGameEngine_Mobile.h#L7201)

![image](https://github.com/Johnnyg63/OLCPGEMobile_AndroidStudio/assets/49657842/5658a52c-930a-49fa-9338-8ca0ba1f377a)

So yes, I guess this PR should fix it. Thanks again for your work and have a great day!
